### PR TITLE
Leaflet 0.8-dev fix by removing event bind of undefined method

### DIFF
--- a/src/L.CircleEditor.js
+++ b/src/L.CircleEditor.js
@@ -51,7 +51,6 @@ L.CircleEditor = L.Circle.extend ({
 		this._markers = [];
 
 		var markerCenter = this._createMarker(this._latlng, 0, true);
-    //markerCenter.on('click', this._onCenterMarkerClick, this);
 		this._markers.push(markerCenter);
 
 		var circleBounds = this.getBounds(),

--- a/src/L.CircleEditor.js
+++ b/src/L.CircleEditor.js
@@ -51,7 +51,7 @@ L.CircleEditor = L.Circle.extend ({
 		this._markers = [];
 
 		var markerCenter = this._createMarker(this._latlng, 0, true);
-		markerCenter.on('click', this._onCenterMarkerClick, this);
+    //markerCenter.on('click', this._onCenterMarkerClick, this);
 		this._markers.push(markerCenter);
 
 		var circleBounds = this.getBounds(),


### PR DESCRIPTION
Using Leaflet 0.8-dev causes _leafet_id undefined error(as mentioned in an issue; sorry coudln't figure out how to attach this PR to the issue). This was caused by change in latest leaflet build but the real problem was in L.CircleEditor.js.

There is line of code in it on line 54
markerCenter.on('click', this._onCenterMarkerClick, this);

This function _onCenterMarkerClick no longer exists.

Previous leaflet versions handled differently attaching event handlers so there was no error even though the script was trying to attach non existent function.
